### PR TITLE
Fix incorrect count reported for changed records

### DIFF
--- a/disaster_scrapers.py
+++ b/disaster_scrapers.py
@@ -173,8 +173,8 @@ class DeltaScraper(Scraper):
             messages = []
             messages.append(
                 "{} {} changed:".format(
-                    len(removed_ids),
-                    self.noun if len(removed_ids) == 1 else self.noun_plural,
+                    len(changed_records),
+                    self.noun if len(changed_records) == 1 else self.noun_plural,
                 )
             )
             for old_record, new_record in changed_records:


### PR DESCRIPTION
Changed records counts are being reported incorrectly in the detailed view (when `show_changes=True`)